### PR TITLE
Delay the mapvote until end of round if vote is rocked mid-round

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Stored in data/lythos_mapvote/rtv.txt as JSON.
 + **minVote:** Min vote to run mapvote (*default 3*)
 + **maxVote:** Max vote to run mapvote (*default 7*)
 + **percentage:** Percentage between 0 and 1 to choose min votes (*default 0.7*)
-+ **minPlaytime:** Playtime before allow RockTheVote in seconds (*default 180*)
++ **minPlaytime:** Playtime before allow RockTheVote in seconds (*default 90*)
++ **delayUntilEnd:** Delay until the end of round (*default true*)
 
 # Todo
 * random map selection (Something like a roulette)

--- a/lua/mapvote/sv_rtv.lua
+++ b/lua/mapvote/sv_rtv.lua
@@ -80,7 +80,15 @@ end
 
 function RTV:StartMapvoteIfNeeded()
     if self:CountVotes() >= self:GetNecessaryVoteAmount() then
-        MapVote:Start()
+        if self.config.delayUntilEnd and GetRoundState() == ROUND_ACTIVE then
+            PrintMessage(HUD_PRINTTALK, "[GLOBAL] RockTheVote passed. Delaying map vote until end of round")
+            hook.Add("TTTEndRound", "RTVDelay", function()
+                hook.Remove("TTTEndRound", "RTVDelay")
+                MapVote:Start()
+            end)
+        else
+            MapVote:Start()
+        end
     end
 end
 
@@ -113,7 +121,8 @@ function RTV:InitConfig()
         minVote = 3,
         maxVote = 7,
         percentage = 0.4,
-        minPlaytime = 180 
+        minPlaytime = 90,
+        delayUntilEnd = true
     }
     self.config = defaultConfig
 


### PR DESCRIPTION
Add config parameter to disable it. Enabled by default. Since the map vote has to wait until end of round, lower minPlaytime so it ends after first time preparation, as there's no consequences to RTVing mid-round anymore.